### PR TITLE
Fix backslashes

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Following the steps below you can create the same shortcut for Google Drive.
 
 - Download this repository.
 - Open  **GoogleDrive.reg**  in your favourite text editor.
-- Update the %USERPROFILE% values for TargetFolderPath so that the final value is the full path to your Google Drive folder. Ensure that you use \\ in the folder path structure. eg. &quot;TargetFolderPath&quot;=&quot;C:\\Users\\User name\\Google Drive&quot;
+- Update the %USERPROFILE% values for TargetFolderPath so that the final value is the full path to your Google Drive folder. Ensure that you use `\\` in the folder path structure. eg. `"TargetFolderPath"="C:\\Users\\User name\\Google Drive"`
 - Save all changes
 - Double-click  **GoogleDrive.reg**  to install and ensure you click yes when prompted.
 


### PR DESCRIPTION
Double backslashes in README.md file are replaced with single backslashes when the file is rendered as html. It's better to write them as inline code.